### PR TITLE
Improve PDF extraction, add kr-spacing and LanguageTool checkers

### DIFF
--- a/checkers/language_tool_checker.py
+++ b/checkers/language_tool_checker.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from typing import Dict
+from .base import BaseChecker
+
+class LanguageToolChecker(BaseChecker):
+    """LanguageTool 기반 맞춤법/문법 검사기."""
+    name = "languagetool"
+
+    def __init__(self):
+        try:
+            import language_tool_python  # type: ignore
+            self.tool = language_tool_python.LanguageTool('ko')
+            self._available = True
+        except Exception as e:
+            print(f"경고: LanguageTool 초기화 실패: {e}")
+            self._available = False
+            self.tool = None
+
+    def check(self, sentence: str) -> Dict:
+        if not self._available or self.tool is None:
+            return {"flag": False, "meta": {"error": "languagetool 모듈 없음"}}
+
+        matches = self.tool.check(sentence)
+        if not matches:
+            return {"flag": False}
+
+        suggestions = []
+        for m in matches:
+            if m.replacements:
+                suggestions.append(m.replacements[0])
+        return {
+            "flag": True,
+            "suggestions": suggestions,
+            "meta": {"match_count": len(matches)}
+        }
+
+    def shutdown(self):
+        try:
+            if self.tool:
+                self.tool.close()
+        except Exception:
+            pass

--- a/checkers/spacing_checker.py
+++ b/checkers/spacing_checker.py
@@ -5,26 +5,26 @@ from typing import Dict, Optional
 from .base import BaseChecker
 
 class SpacingChecker(BaseChecker):
-    """PyKoSpacing 기반 띄어쓰기 검사기."""
+    """kr-spacing 기반 띄어쓰기 검사기."""
     name = "spacing"
-    
+
     def __init__(self, cache_file: str = "spacing_cache.json"):
         self.cache_file = cache_file
         self.cache = self._JsonCache(cache_file)
-        
-        # pykospacing 모듈 import 시도
+
+        # kr-spacing 모듈 import 시도
         try:
-            from pykospacing import Spacing
-            self.model = Spacing()
+            from krspacing import KRSpacing  # type: ignore
+            self.model = KRSpacing()
             self._available = True
         except ImportError:
-            print("경고: pykospacing 모듈을 찾을 수 없습니다. pip install pykospacing")
+            print("경고: krspacing 모듈을 찾을 수 없습니다. pip install kr-spacing")
             self._available = False
     
     def check(self, sentence: str) -> Dict:
         """문장의 띄어쓰기를 검사합니다."""
         if not self._available:
-            return {"flag": False, "meta": {"error": "pykospacing 모듈 없음"}}
+            return {"flag": False, "meta": {"error": "krspacing 모듈 없음"}}
         
         # 캐시 확인
         cached = self.cache.get(sentence)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,7 @@ rapidfuzz==3.6.1
 pyyaml==6.0.1
 pytesseract==0.3.10
 pillow==10.1.0
+pdfplumber==0.11.0
+kr-spacing==0.5.1
+language-tool-python==2.7.1
 git+https://github.com/ssut/py-hanspell.git

--- a/viewer.html
+++ b/viewer.html
@@ -722,6 +722,28 @@
       const f = e.dataTransfer.files?.[0]; if (f){ pendingFile=f; }
     });
 
+    // 자동 로드: 동일 경로의 review.csv 있으면 시도
+    async function tryAutoLoad() {
+      try {
+        const resp = await fetch('out/review.csv').catch(()=>null);
+        if (resp && resp.ok) {
+          const text = await resp.text();
+          rawData = parseCSVText(text).map(normalizeRow);
+          if (rawData.length) {
+            show($('statsWrap'), true);
+            show($('chartsWrap'), true);
+            show($('filters'), true);
+            show($('tableWrap'), true);
+            summarize();
+            buildErrorTypeBox();
+            applyFilters();
+          }
+        }
+      } catch (e) {
+        console.warn('auto load failed', e);
+      }
+    }
+
     // ------- Load / Init -------
     async function loadFile(file) {
       try {
@@ -805,6 +827,7 @@
       show($('chartsWrap'), false);
       show($('filters'), false);
       show($('tableWrap'), false);
+      tryAutoLoad();
     })();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- enhance PDF text extraction with optional pdfplumber for tables and add page counting helper
- replace PyKoSpacing with kr-spacing and add LanguageTool-based checker
- streamline processing loop, reuse thread pool, and auto-load default results in viewer

## Testing
- `python -m py_compile utils/pdf.py checkers/spacing_checker.py checkers/language_tool_checker.py run.py`
- `python run.py "pdf/PM 2권 최종.pdf" --rule --spacing --languagetool --hanspell --workers 2 --out-dir out_test` *(interrupted after start)*
- `pip install pdfplumber` *(fails: Could not find a version that satisfies the requirement)*
- `pip install krspacing` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_689b76bbd79c8320ae429dd718b03da3