### PR TITLE
Add web interface for PDF typo checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ pip install -r requirements.txt
 python run.py
 ```
 
+### 웹 UI 사용
+
+간단한 웹 인터페이스를 통해 PDF를 업로드하고 검사기를 선택할 수 있습니다.
+
+```bash
+python app.py
+```
+
+브라우저에서 [http://localhost:5000](http://localhost:5000) 에 접속하여 PDF 파일을 업로드한 뒤
+검사기(Hanspell, Spacing, Rule, LanguageTool)와 출력 형식을 선택합니다.
+처리가 완료되면 `out/review.csv`와 `out/review.xlsx` 링크가 제공되며
+`viewer.html`로 결과를 시각화할 수도 있습니다.
+
 ## 출력 파일
 
 - `out/review.xlsx`: 검수 결과 (Excel)

--- a/app.py
+++ b/app.py
@@ -1,0 +1,51 @@
+import os
+import uuid
+import subprocess
+from flask import Flask, request, jsonify
+
+app = Flask(__name__, static_folder=".", static_url_path="")
+
+# Serve the uploader HTML
+@app.get("/")
+def index():
+    return app.send_static_file("uploader.html")
+
+# API endpoint to process PDF
+@app.post("/api/process")
+def api_process():
+    pdf = request.files.get("pdf")
+    if not pdf:
+        return jsonify({"error": "PDF 파일이 필요합니다."}), 400
+
+    # Save uploaded PDF
+    os.makedirs("pdf", exist_ok=True)
+    filename = f"{uuid.uuid4().hex}.pdf"
+    pdf_path = os.path.join("pdf", filename)
+    pdf.save(pdf_path)
+
+    # Build command for run.py
+    cmd = ["python", "run.py", pdf_path]
+    fmt = request.form.get("format", "both")
+    cmd += ["--format", fmt]
+    checkers = request.form.getlist("checkers")
+    if "hanspell" in checkers:
+        cmd.append("--hanspell")
+    if "spacing" in checkers:
+        cmd.append("--spacing")
+    if "rule" in checkers:
+        cmd.append("--rule")
+    if "languagetool" in checkers:
+        cmd.append("--languagetool")
+
+    # Run detection
+    subprocess.run(cmd, check=True)
+
+    result = {}
+    if fmt in ["csv", "both"]:
+        result["csv"] = "/out/review.csv"
+    if fmt in ["xlsx", "both"]:
+        result["xlsx"] = "/out/review.xlsx"
+    return jsonify(result)
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ pdfplumber==0.11.0
 kr-spacing==0.5.1
 language-tool-python==2.7.1
 git+https://github.com/ssut/py-hanspell.git
+
+Flask==3.0.0

--- a/uploader.html
+++ b/uploader.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8" />
+<title>PDF 오탈자 검사기</title>
+</head>
+<body>
+<h1>PDF 오탈자 검사기</h1>
+<form id="form">
+  <div>
+    <label>PDF 파일: <input type="file" name="pdf" accept="application/pdf" required></label>
+  </div>
+  <fieldset>
+    <legend>검사기 선택</legend>
+    <label><input type="checkbox" name="checkers" value="hanspell" checked> Hanspell</label>
+    <label><input type="checkbox" name="checkers" value="spacing" checked> Spacing</label>
+    <label><input type="checkbox" name="checkers" value="rule" checked> Rule</label>
+    <label><input type="checkbox" name="checkers" value="languagetool" checked> LanguageTool</label>
+  </fieldset>
+  <div>
+    <label>출력 형식:
+      <select name="format">
+        <option value="both">CSV & XLSX</option>
+        <option value="csv">CSV</option>
+        <option value="xlsx">XLSX</option>
+      </select>
+    </label>
+  </div>
+  <button type="submit">검수 시작</button>
+</form>
+<div id="result"></div>
+<script>
+const form = document.getElementById('form');
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const fd = new FormData(form);
+  const res = await fetch('/api/process', {method: 'POST', body: fd});
+  const data = await res.json();
+  const result = document.getElementById('result');
+  if (data.error) {
+    result.textContent = data.error;
+    return;
+  }
+  let html = '';
+  if (data.csv) html += `<a href="${data.csv}" download>CSV 다운로드</a><br>`;
+  if (data.xlsx) html += `<a href="${data.xlsx}" download>XLSX 다운로드</a><br>`;
+  if (!html) html = '파일이 생성되지 않았습니다.';
+  result.innerHTML = html + '<p><a href="viewer.html" target="_blank">viewer.html로 열기</a></p>';
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add Flask server (`app.py`) exposing API to run typo checks on uploaded PDFs
- Provide `uploader.html` for uploading PDFs and selecting checkers/output format
- Document web UI usage and add Flask dependency

## Testing
- `python -m py_compile app.py run.py`


------
https://chatgpt.com/codex/tasks/task_e_689b79e85fe08320a2bc88e0b300af52